### PR TITLE
Add expiration status display in item table

### DIFF
--- a/PantryDjango/Views/FoodItems/Index.cshtml
+++ b/PantryDjango/Views/FoodItems/Index.cshtml
@@ -47,14 +47,25 @@
         </tr>
     </thead>
     <tbody>
-@foreach (var item in Model) {
+@foreach (var item in Model) 
+ {
+     var daysUntilExpire = (item.ExpirationDate - DateTime.Today).TotalDays;
         <tr>
             <td>
                 @Html.DisplayFor(modelItem => item.Name)
             </td>
             <td>
                 @Html.DisplayFor(modelItem => item.ExpirationDate)
+                    @if (daysUntilExpire <= 3 && daysUntilExpire >= 0)
+                    {
+                        <span class="badge bg-warning text-dark ms-2">Expiring Soon</span>
+                    }
+                    @if (daysUntilExpire < 0)
+                    {
+                        <span class="badge bg-danger text-white ms-2">Expired</span>
+                    }
             </td>
+
             <td>
                 @Html.DisplayFor(modelItem => item.Quantity)
             </td>


### PR DESCRIPTION
Updated the item display logic to show expiration status. Items now indicate if they are "Expiring Soon" (within 3 days) or "Expired" (past expiration date) using visual badges,