### PR TITLE
Improve camera access for rear-facing video stream

### DIFF
--- a/PantryDjango/wwwroot/js/ocr.js
+++ b/PantryDjango/wwwroot/js/ocr.js
@@ -4,7 +4,11 @@
 
     try {
         // 1. 카메라 접근
-        const stream = await navigator.mediaDevices.getUserMedia({ video: { ideal: "environment" } }); // Make efault to rear camera
+        const stream = await navigator.mediaDevices.getUserMedia({
+            video: {
+                facingMode: { ideal: "environment" }  
+            }
+        }); // Make default to rear camera
         video.srcObject = stream;
 
         // 2. 영상 재생 보장


### PR DESCRIPTION
Updated the video stream request to use the `facingMode` property with an `ideal` value of "environment" to explicitly request the rear camera, enhancing compatibility with devices that support this feature.